### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -683,7 +683,11 @@ $.extend( $.validator, {
 			} );
 		},
 
+		// Accepts only DOM elements, jQuery objects, or safe selectors (not HTML fragments).
 		clean: function( selector ) {
+			if ( typeof selector === "string" && /^\s*<[\s\S]*>/.test(selector) ) {
+				throw new Error("Selector passed to clean() may be an HTML fragment. This is unsafe!");
+			}
 			return $( selector )[ 0 ];
 		},
 
@@ -1068,6 +1072,10 @@ $.extend( $.validator, {
 				element = this.findByName( element.name );
 			}
 
+			// Prevent unsafe HTML fragments from being passed to $
+			if ( typeof element === "string" && /^\s*<[\s\S]*>/.test(element) ) {
+				throw new Error("Element selector in validationTargetFor() is an HTML fragment. This is unsafe!");
+			}
 			// Always apply ignore filter
 			return $( element ).not( this.settings.ignore )[ 0 ];
 		},


### PR DESCRIPTION
Potential fix for [https://github.com/qfChenMSFT/sampleapp/security/code-scanning/7](https://github.com/qfChenMSFT/sampleapp/security/code-scanning/7)

To fix this issue, we need to eliminate the chance that a string starting with `<` can flow from plugin options through to a jQuery selector/argument, resulting in HTML being injected. Specifically, anywhere user-controlled strings are passed to `$()`, such as in `clean`, `validationTargetFor`, and related methods, we must ensure that (1) only selectors are allowed, or (2) validate the type of the input and reject/escape HTML fragments, or (3) issue clear, strong documentation for plugin users about safe usage, but (2) is preferred.

The safest and least breaking fix is to update the relevant internal jQuery plugin methods (`clean`, `validationTargetFor`, etc.) to check whether the input looks like an HTML fragment (string starting with `<`), and in such cases either throw an error, ignore, or sanitize. For example, in `clean`, check if the selector is a string and starts with `<`, and if so, avoid passing it to `$()`. Alternatively (and more robustly), we can force such methods to always accept only DOM elements or jQuery objects, not strings, or at least document and enforce this. The same check should be performed in locations where `validationTargetFor` is used.

Change only the methods you have seen in the provided code, with local context included. No new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
