### PR TITLE
Potential fix for code scanning alert no. 6: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -684,7 +684,18 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			// Only interpret a string selector as a selector, never as HTML to prevent XSS
+			if ( typeof selector === "string" ) {
+				// Use currentForm as context if available
+				if ( this.currentForm ) {
+					return $( this.currentForm ).find( selector )[0];
+				} else {
+					// Fallback: use document context, still .find() to avoid HTML construction
+					return $( document ).find( selector )[0];
+				}
+			}
+			// If it's a DOM node or jQuery object, just normalize to a DOM node
+			return $( selector )[0];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/qfChenMSFT/sampleapp/security/code-scanning/6](https://github.com/qfChenMSFT/sampleapp/security/code-scanning/6)

To fix this issue, ensure that the `clean` method only ever interprets its argument as a selector—not HTML. The canonical fix is to use `$.find(selector)[0]` (or more accurately `$(context).find(selector)[0]`), instead of passing a possibly untrusted string directly to `$()`, because jQuery treats strings starting with `<` as HTML to create elements, which is unsafe. The best fix, preserving existing functionality, is to rewrite `clean` to only ever search for elements within the current form context, using `.find(selector)` from a known safe context (e.g., the form or `document`), not allowing HTML parsing via `$()` on unvalidated strings.  

In `clean`, replace `return $(selector)[0];` with `return this.currentForm ? $(this.currentForm).find(selector)[0] : $(selector)[0];`, or simply always requiring a context to avoid HTML parsing entirely, depending on the plugin’s architecture. If the method *must* accept both selectors and raw DOM elements, you can defensively check the type: if it is already a Node or a jQuery object, return as needed; if it is a string, only ever pass it through `.find()`. If you can't guarantee a context, then at least explicitly document and check for such cases.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
