### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,6 @@
 name: Build and Deploy .NET App
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qfChenMSFT/sampleapp/security/code-scanning/5](https://github.com/qfChenMSFT/sampleapp/security/code-scanning/5)

To fix this problem, you should add a `permissions:` block specifying the least privilege required for both jobs. The best practice is to put a minimal `permissions:` block at the top level (applying to all jobs), or at the individual job level if permission requirements differ per job. For these jobs, uploading and downloading artifacts and interacting with Azure do not require repository write access, so `contents: read` is sufficient. If neither job needs to open or update pull requests or issues, only content read access is needed.

You should edit `.github/workflows/build-and-deploy.yml` and add the following lines after the `name:` declaration and before the `on:` block:

```yaml
permissions:
  contents: read
```

This will ensure all jobs in the workflow only receive the minimum permissions required for read-only access to repository contents. If you later need expanded permissions for specific jobs, you can augment those jobs individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
