### PR TITLE
Add security policy documentation

### DIFF
--- a/.github/workflows/SECURITY.md
+++ b/.github/workflows/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+Thank you for your interest in the security of this project! We take security seriously and appreciate your efforts to make this repository safer for everyone.
+
+## Supported Versions
+
+We currently support the latest stable release. Please ensure you are running the most recent version before reporting security issues.
+
+| Version    | Supported          |
+|------------|-------------------|
+| Latest     | ✔️                |
+| Older      | ❌                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please do **not** create a public issue. Instead, follow these steps:
+
+1. **Contact Us Privately:**  
+   Send an email to [security@yourdomain.com] with details of the vulnerability.  
+   Alternatively, use GitHub’s [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-security-advisories#privately-reporting-a-security-vulnerability).
+
+2. **Include in Your Report:**  
+   - A clear description of the vulnerability.
+   - Steps to reproduce the issue.
+   - Any relevant logs, screenshots, or code snippets.
+   - Your contact information for follow-up.
+
+3. **Response Time:**  
+   We aim to respond to security reports within **72 hours**. You will receive an acknowledgment and updates on progress as we investigate the issue.
+
+## Security Updates
+
+If a vulnerability is confirmed, we will:
+- Release a patch as soon as possible.
+- Announce the update in the repository’s release notes.
+- Credit responsible disclosure if desired.
+
+## Security Best Practices
+
+- Keep your dependencies up-to-date.
+- Do not share sensitive credentials in issues or pull requests.
+- Use strong passwords and enable two-factor authentication on your accounts.
+
+---
+
+**Thank you for helping keep our project secure!**


### PR DESCRIPTION
This pull request adds a new security policy document to the repository, outlining the process for reporting vulnerabilities, supported versions, and best practices for contributors.

Security policy documentation:

* Added `.github/workflows/SECURITY.md` with guidelines for reporting vulnerabilities privately, supported version information, response times, and security best practices.