### PR TITLE
Add C# package ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
+  - package-ecosystem: "csharp" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. The package ecosystem monitored by Dependabot has been changed from npm (Node.js) to csharp (.NET), which will affect which dependencies are automatically updated.

- Changed the `package-ecosystem` in `.github/dependabot.yml` from "npm" to "csharp" to switch dependency updates from Node.js packages to .NET packages.